### PR TITLE
move exporters to own file sand add memory exporter

### DIFF
--- a/disks.go
+++ b/disks.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type harddrive struct {
+	device     string
+	size       string
+	used       string
+	available  string
+	percentage string
+	mountpoint string
+}
+
+func ExportDisks() {
+	setting_disk_percentage, _ := Cfg.Section("collectors").Key("disk_space_percentage").Bool()
+
+	//Disk percentage collector
+	if setting_disk_percentage {
+		fmt.Println("Disk space percentage collector enabled")
+
+		out, err := exec.Command("df", "-h").Output()
+		if err != nil {
+			fmt.Println(err)
+		}
+		dfout := strings.Split(string(out[:]), "\n")
+		for _, d := range dfout {
+			//@todo make prefix /dev/X come from config file and be a list
+			//@todo do below for each value in list
+			if strings.HasPrefix(d, "/dev/vda") {
+				curdev := strings.Fields(d)
+				hd := harddrive{
+					curdev[0],                               //device ex /dev/sda1
+					curdev[1],                               //size ex 20G or 2000MB
+					curdev[2],                               //used size ex 13G or 4000MB
+					curdev[3],                               //available size ex 13G or 4000MB
+					strings.Replace(curdev[4], "%", "", -1), //percentage used but we strip the percent sign 20% > 20
+					curdev[5],                               //mount point ex /boot/efi
+				}
+				tempcollector := prometheus.NewGauge(prometheus.GaugeOpts{
+					Name: "hdstats_" + hd.device[strings.LastIndex(hd.device, "/")+1:],
+					Help: "percentage for mountpoint " + hd.device,
+				})
+				//@todo construct prometheus stat name from either device or mountpoint based on the configuration file
+				//register if not already registered
+				err = prometheus.DefaultRegisterer.Register(tempcollector)
+				if err != nil {
+					fmt.Println("RegistrationError", err)
+				}
+				percent, err := strconv.ParseFloat(hd.percentage, 32)
+				if err != nil {
+					fmt.Println("Error converting disk used percentage to float", err)
+				}
+				tempcollector.Set(percent)
+				//for thisdev := range prometheus
+			}
+			//fmt.Println(d)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,14 +4,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 
 	"gopkg.in/ini.v1"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -34,72 +29,23 @@ import (
 // 	prometheus.MustRegister(diskPerc)
 // }
 
-type harddrive struct {
-	device     string
-	size       string
-	used       string
-	available  string
-	percentage string
-	mountpoint string
-}
+//@todo if there is no config file then create one with defaults
+var Cfg, _ = ini.Load("/etc/prometheus_system_exporter/settings.ini") // initialize a CFG
+// if err != nil {
+// 	fmt.Printf("Fail to read file: %v", err)
+// 	os.Exit(1)
+// }
 
 //@todo register the binary as a service
+//@todo make matching exporter files for windows
 func main() {
-	//@todo if there is no config file then create one with defaults
-	cfg, err := ini.Load("/etc/prometheus_system_exporter/settings.ini") // initialize a CFG
-	if err != nil {
-		fmt.Printf("Fail to read file: %v", err)
-		os.Exit(1)
-	}
 
 	//Get the settings from config file
 	//fmt.Println("App Mode:", cfg.Section("").Key("app_mode").String())
-	fmt.Println("Allowed Drive Prefixes", cfg.Section("drives").Key("allowed_prefixes").String())
-	setting_disk_percentage, _ := cfg.Section("collectors").Key("disk_space_percentage").Bool()
-
-	//@todo each collector should be it's own function or even its own file?
-	//Disk percentage collector
-	if setting_disk_percentage {
-		fmt.Println("Disk space percentage collector enabled")
-
-		out, err := exec.Command("df", "-h").Output()
-		if err != nil {
-			fmt.Println(err)
-		}
-		dfout := strings.Split(string(out[:]), "\n")
-		for _, d := range dfout {
-			//@todo make prefix /dev/X come from config file and be a list
-			//@todo do below for each value in list
-			if strings.HasPrefix(d, "/dev/vda") {
-				curdev := strings.Fields(d)
-				hd := harddrive{
-					curdev[0],                               //device ex /dev/sda1
-					curdev[1],                               //size ex 20G or 2000MB
-					curdev[2],                               //used size ex 13G or 4000MB
-					curdev[3],                               //available size ex 13G or 4000MB
-					strings.Replace(curdev[4], "%", "", -1), //percentage used but we strip the percent sign 20% > 20
-					curdev[5],                               //mount point ex /boot/efi
-				}
-				tempcollector := prometheus.NewGauge(prometheus.GaugeOpts{
-					Name: "hdstats_" + hd.device[strings.LastIndex(hd.device, "/")+1:],
-					Help: "percentage for mountpoint " + hd.device,
-				})
-				//@todo construct prometheus stat name from either device or mountpoint based on the configuration file
-				//register if not already registered
-				err = prometheus.DefaultRegisterer.Register(tempcollector)
-				if err != nil {
-					fmt.Println("RegistrationError", err)
-				}
-				percent, err := strconv.ParseFloat(hd.percentage, 32)
-				if err != nil {
-					fmt.Println("Error converting disk used percentage to float", err)
-				}
-				tempcollector.Set(percent)
-				//for thisdev := range prometheus
-			}
-			//fmt.Println(d)
-		}
-	}
+	fmt.Println("Allowed Drive Prefixes", Cfg.Section("drives").Key("allowed_prefixes").String())
+	//@todo check if these need to be in an infinite loop to update
+	go ExportDisks()
+	go ExportMemory()
 
 	// The Handler function provides a default handler to expose metrics
 	// via an HTTP server. "/metrics" is the usual endpoint for that.

--- a/memory.go
+++ b/memory.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type memory struct {
+	total     string
+	used      string
+	free      string
+	shared    string
+	cache     string
+	available string
+}
+
+func ExportMemory() {
+	setting_memory_percentage, _ := Cfg.Section("collectors").Key("memory_percentage").Bool()
+
+	//@todo export other stats as well like total memory etc
+	//Disk percentage collector
+	if setting_memory_percentage {
+		fmt.Println("Memory percentage collector enabled")
+
+		out, err := exec.Command("free").Output()
+		if err != nil {
+			fmt.Println(err)
+		}
+		dfout := strings.Split(string(out[:]), "\n")
+		for _, d := range dfout {
+			if strings.HasPrefix(d, "Mem:") {
+				curdev := strings.Fields(d)
+				mem := memory{
+					curdev[1], //toal memory
+					curdev[2], //used memory
+					curdev[3], //free memory
+					curdev[4], //shared memory
+					curdev[5], //buffer/cache
+					curdev[6], //available memory
+				}
+				tempcollector := prometheus.NewGauge(prometheus.GaugeOpts{
+					Name: "mem_used_percentage",
+					Help: "current memory used in percentage",
+				})
+				//register if not already registered
+				err = prometheus.DefaultRegisterer.Register(tempcollector)
+				if err != nil {
+					fmt.Println("RegistrationError", err)
+				}
+				used, _ := strconv.ParseFloat(mem.used, 64)
+				total, _ := strconv.ParseFloat(mem.total, 64)
+				large_percent := used / total * 10000
+				fmt.Println(large_percent)
+				small_percent := int(math.Round(large_percent))
+				percent := float64(small_percent) / 100
+				fmt.Println(percent)
+				tempcollector.Set(percent)
+			}
+		}
+	}
+}


### PR DESCRIPTION
exporters are now each their own file based on the type of stat we are sending

This also adds the new memory exporter to be used for all memory statistics